### PR TITLE
Fix handling of missing plans in data fetching and storage processes

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -509,6 +509,13 @@ async def process_req_plan(req_dataset, req_create_lyr):
         current_plan_index = int(current_plan_index)
         plan = await get_plan(plan_name)
 
+        if (
+            plan is None
+            or current_plan_index is None
+            or len(plan) <= current_plan_index
+        ):
+            return req_dataset, plan_name, "", current_plan_index, bknd_dataset_id
+
         if isinstance(req_dataset, ReqLocation):
             search_info = plan[current_plan_index].split("_")
             req_dataset.lng, req_dataset.lat, req_dataset.radius = (

--- a/storage.py
+++ b/storage.py
@@ -650,7 +650,7 @@ async def load_dataset(dataset_id: str) -> Dict:
         # Load the plan
         plan = await get_plan(plan_name)
         if not plan:
-            raise HTTPException(status_code=404, detail="Plan not found")
+            return {}
         # Initialize an empty list to store all datasets
         all_datasets = []
         # Load and concatenate all datasets up to the current page number


### PR DESCRIPTION
- Update `process_req_plan` to return early if the plan is None, the current plan index is None, or the index is out of bounds.
- Modify `load_dataset` to return an empty dictionary instead of raising an HTTPException when the plan is not found, improving error handling.