### PR TITLE
Add radius zoom multiplier and popularity score calculation

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -80,6 +80,17 @@ EXPANSION_DISTANCE_KM = 30.0  # for each side from the center of the bounding bo
 _LOCATION_CACHE = {}
 
 
+RADIUS_ZOOM_MULTIPLIER = {
+    30000: 1000, # 1
+    15000: 500, # 2
+    7500: 250, # 3
+    3750: 125, # 4
+    1875: 62.5, # 5
+    937.5: 31.25, # 6
+    468.75: 15.625 # 7
+}
+
+
 def get_point_at_distance(start_point: tuple, bearing: float, distance: float):
     """
     Calculate the latitude and longitude of a point at a given distance and bearing from a start point.
@@ -404,6 +415,12 @@ async def fetch_ggl_nearby(req_dataset: ReqLocation, req_create_lyr: ReqFetchDat
 
         if ggl_api_resp:
             dataset = convert_strings_to_ints(dataset)
+
+            zoom_multiplier = RADIUS_ZOOM_MULTIPLIER.get(req_dataset.radius)
+
+            for idx, feature in enumerate(dataset["features"]):
+                feature["properties"]["popularity_score"] = calculate_category_multiplier(idx) * zoom_multiplier
+
             bknd_dataset_id = await store_data_resp(
                 req_dataset, dataset, bknd_dataset_id
             )
@@ -422,6 +439,16 @@ async def fetch_ggl_nearby(req_dataset: ReqLocation, req_create_lyr: ReqFetchDat
 
     return dataset, bknd_dataset_id, next_page_token, plan_name
 
+def calculate_category_multiplier(index):
+    """Calculate category multiplier based on result position."""
+    if 0 <= index < 5:  # Category A
+        return 1.0
+    elif 5 <= index < 10:  # Category B
+        return 0.8
+    elif 10 <= index < 15:  # Category C
+        return 0.6
+    else:  # Category D
+        return 0.4
 
 async def rectify_plan(plan_name, current_plan_index):
     plan = await get_plan(plan_name)

--- a/mapbox_connector.py
+++ b/mapbox_connector.py
@@ -2,6 +2,8 @@ from all_types.google_dtypes import GglResponse
 from all_types.response_dtypes import MapData
 from fastapi import HTTPException
 
+from popularity_algo import RADIUS_ZOOM_MULTIPLIER, calculate_category_multiplier
+
 
 class MapBoxConnector:
 
@@ -26,7 +28,7 @@ class MapBoxConnector:
         }
 
     @classmethod
-    async def new_ggl_to_boxmap(cls, ggl_api_resp) -> MapData:
+    async def new_ggl_to_boxmap(cls, ggl_api_resp, radius) -> MapData:
         if not ggl_api_resp:  # This will handle None, empty string, or empty list
             return MapData(
                 type="FeatureCollection",
@@ -41,6 +43,11 @@ class MapBoxConnector:
         if features:
             # Extract all property keys from the first feature's properties
             feature_properties = list(features[0]["properties"].keys())
+
+        zoom_multiplier = RADIUS_ZOOM_MULTIPLIER.get(radius)
+
+        for idx, feature in enumerate(features):
+            feature["properties"]["popularity_score"] = calculate_category_multiplier(idx) * zoom_multiplier
         
         business_data = MapData(
             type="FeatureCollection",

--- a/popularity_algo.py
+++ b/popularity_algo.py
@@ -1,0 +1,21 @@
+
+RADIUS_ZOOM_MULTIPLIER = {
+    30000.0: 1000, # 1
+    15000.0: 500, # 2
+    7500.0: 250, # 3
+    3750.0: 125, # 4
+    1875.0: 62.5, # 5
+    937.5: 31.25, # 6
+    468.75: 15.625 # 7
+}
+
+def calculate_category_multiplier(index):
+    """Calculate category multiplier based on result position."""
+    if 0 <= index < 5:  # Category A
+        return 1.0
+    elif 5 <= index < 10:  # Category B
+        return 0.8
+    elif 10 <= index < 15:  # Category C
+        return 0.6
+    else:  # Category D
+        return 0.4


### PR DESCRIPTION
- Introduced a RADIUS_ZOOM_MULTIPLIER dictionary to map radius values to zoom levels.
- Enhanced the fetch_ggl_nearby function to calculate and assign a popularity score to each feature based on its index and the corresponding zoom multiplier.
- Added a new helper function, calculate_category_multiplier, to determine the multiplier based on the feature's position in the dataset.